### PR TITLE
Matplotlib deprecation updates.

### DIFF
--- a/pyro/analysis/graphical.py
+++ b/pyro/analysis/graphical.py
@@ -400,7 +400,8 @@ class Animator:
         
         
         if is_3d:
-            self.ani_ax = p3.Axes3D( self.ani_fig )
+            self.ani_ax = p3.Axes3D(self.ani_fig)
+            self.ani_fig.add_axes(self.ani_ax)
             self.ani_ax.set_xlim3d(self.ani_domains[0][0])
             self.ani_ax.set_xlabel('X')
             self.ani_ax.set_ylim3d(self.ani_domains[0][1])

--- a/pyro/analysis/graphical.py
+++ b/pyro/analysis/graphical.py
@@ -90,7 +90,7 @@ class TrajectoryPlotter:
             plots = [plots]
         #######################################################################
 
-        simfig.canvas.set_window_title('Trajectory for ' + self.sys.name)
+        simfig.canvas.manager.set_window_title('Trajectory for ' + self.sys.name)
 
         j = 0 # plot index
 
@@ -309,7 +309,7 @@ class Animator:
         
         # Plot
         self.showfig = plt.figure(figsize=self.figsize, dpi=self.dpi)
-        self.showfig.canvas.set_window_title('2D Configuration of ' + 
+        self.showfig.canvas.manager.set_window_title('2D Configuration of ' + 
                                             self.sys.name )
         self.showax = self.showfig.add_subplot(111, autoscale_on=False )
         self.showax.grid()
@@ -338,7 +338,7 @@ class Animator:
         
         # Plot
         self.show3fig = plt.figure(figsize=self.figsize, dpi=self.dpi)
-        self.show3fig.canvas.set_window_title('3D Configuration of ' + 
+        self.show3fig.canvas.manager.set_window_title('3D Configuration of ' + 
                                             self.sys.name )
         self.show3ax = self.show3fig.gca(projection='3d')
                 
@@ -407,14 +407,14 @@ class Animator:
             self.ani_ax.set_ylabel('Y')
             self.ani_ax.set_zlim3d(self.ani_domains[0][2])
             self.ani_ax.set_zlabel('Z')
-            self.ani_fig.canvas.set_window_title('3D Animation of ' + 
+            self.ani_fig.canvas.manager.set_window_title('3D Animation of ' + 
                                             self.sys.name )
         else:
             self.ani_ax = self.ani_fig.add_subplot(111, autoscale_on=True)
             self.ani_ax.axis('equal')
             self.ani_ax.set_xlim(  self.ani_domains[0][self.x_axis] )
             self.ani_ax.set_ylim(  self.ani_domains[0][self.y_axis] )
-            self.ani_fig.canvas.set_window_title('2D Animation of ' + 
+            self.ani_fig.canvas.manager.set_window_title('2D Animation of ' + 
                                             self.sys.name )
             
         self.ani_ax.tick_params(axis='both', which='both', labelsize=

--- a/pyro/analysis/phaseanalysis.py
+++ b/pyro/analysis/phaseanalysis.py
@@ -96,7 +96,7 @@ class PhasePlot:
         
         self.phasefig = plt.figure( figsize = self.figsize , dpi = self.dpi,
                                    frameon=True)
-        self.phasefig.canvas.set_window_title('Phase plane of ' + 
+        self.phasefig.canvas.manager.set_window_title('Phase plane of ' + 
                                                 self.cds.name )
         
         

--- a/pyro/dynamic/manipulator.py
+++ b/pyro/dynamic/manipulator.py
@@ -239,7 +239,7 @@ class Manipulator( mechanical.MechanicalSystem ):
         simfig , plots = plt.subplots( l, sharex=True, figsize=figsize,
                                       dpi=dpi, frameon=True)
             
-        simfig.canvas.set_window_title('End-Effector trajectory for ' + 
+        simfig.canvas.manager.set_window_title('End-Effector trajectory for ' + 
                                        self.name)
         
         

--- a/pyro/dynamic/tranferfunction.py
+++ b/pyro/dynamic/tranferfunction.py
@@ -99,7 +99,7 @@ class TransferFunction( ContinuousDynamicSystem ):
             plots[i].grid(True)
             plots[i].tick_params( labelsize = self.fontsize )
         
-        fig.canvas.set_window_title('Bode plot of ' + self.name)
+        fig.canvas.manager.set_window_title('Bode plot of ' + self.name)
         
         plt.show()
         
@@ -117,7 +117,7 @@ class TransferFunction( ContinuousDynamicSystem ):
         plot.grid(True)
         plot.tick_params( labelsize = self.fontsize )
         
-        fig.canvas.set_window_title('Poles and zeros of ' + self.name)
+        fig.canvas.manager.set_window_title('Poles and zeros of ' + self.name)
         
         plt.show()
         

--- a/pyro/planning/randomtree.py
+++ b/pyro/planning/randomtree.py
@@ -413,7 +413,7 @@ class RRT:
         self.fig_tree = plt.figure(figsize=(3, 2), dpi=300, frameon=True)
         
         # Set window title
-        self.fig_tree.canvas.set_window_title('RRT tree search for ' + 
+        self.fig_tree.canvas.manager.set_window_title('RRT tree search for ' + 
                                             self.sys.name )
         
         # Create axe
@@ -468,7 +468,7 @@ class RRT:
         self.fig_tree_3d = plt.figure( figsize = self.figsize, dpi = self.dpi )
         
         # Set window title
-        self.fig_tree_3d.canvas.set_window_title('RRT tree search for ' + 
+        self.fig_tree_3d.canvas.manager.set_window_title('RRT tree search for ' + 
                                             self.sys.name )
         
         # Create Axe
@@ -530,7 +530,7 @@ class RRT:
         self.fig_tree_dyna = plt.figure(figsize=(3, 2),dpi=300, frameon=True)
         
         # Set window title
-        self.fig_tree_dyna.canvas.set_window_title('RRT tree search for ' + 
+        self.fig_tree_dyna.canvas.manager.set_window_title('RRT tree search for ' + 
                                             self.sys.name )
         
         # Create axe

--- a/pyro/planning/valueiteration.py
+++ b/pyro/planning/valueiteration.py
@@ -276,7 +276,7 @@ class ValueIteration_2D:
                     self.Jplot[i,j] = self.J[i,j]
         
         self.fig1 = plt.figure(figsize=(4, 4),dpi=300, frameon=True)
-        self.fig1.canvas.set_window_title('Cost-to-go')
+        self.fig1.canvas.manager.set_window_title('Cost-to-go')
         self.ax1  = self.fig1.add_subplot(1,1,1)
         
         plt.ylabel(yname, fontsize = self.fontsize)
@@ -306,7 +306,7 @@ class ValueIteration_2D:
         policy_plot = self.u_policy_grid[i].copy()
                 
         self.fig1 = plt.figure(figsize=(4, 4),dpi=300, frameon=True)
-        self.fig1.canvas.set_window_title('Policy for u[%i]'%i)
+        self.fig1.canvas.manager.set_window_title('Policy for u[%i]'%i)
         self.ax1  = self.fig1.add_subplot(1,1,1)
         
         plt.ylabel(yname, fontsize = self.fontsize )
@@ -597,7 +597,7 @@ class ValueIteration_ND:
         yname = self.sys.state_label[1] + ' ' + self.sys.state_units[1]
 
         self.fig_dynamic = plt.figure(figsize= self.figsize, dpi=self.dpi, frameon=True)
-        self.fig_dynamic.canvas.set_window_title('Dynamic Cost-to-go')
+        self.fig_dynamic.canvas.manager.set_window_title('Dynamic Cost-to-go')
         self.ax1_dynamic = self.fig_dynamic.add_subplot(1, 1, 1)
 
         plt.ylabel(yname, fontsize=self.fontsize)
@@ -720,7 +720,7 @@ class ValueIteration_ND:
         policy_plot = self.u_policy_grid[i].copy()
 
         self.fig1 = plt.figure(figsize=(4, 4), dpi=300, frameon=True)
-        self.fig1.canvas.set_window_title('Policy for u[%i]' % i)
+        self.fig1.canvas.manager.set_window_title('Policy for u[%i]' % i)
         self.ax1 = self.fig1.add_subplot(1, 1, 1)
 
         #plot = policy_plot.T if self.n_dim == 2 else policy_plot[..., 0].T
@@ -770,7 +770,7 @@ class ValueIteration_ND:
         print(policy_plot.shape)
 
         self.fig1 = plt.figure()
-        self.fig1.canvas.set_window_title('Policy for u[%i]' % i)
+        self.fig1.canvas.manager.set_window_title('Policy for u[%i]' % i)
         self.ax1 = self.fig1.gca(projection='3d')
 
         plot = policy_plot.T if self.n_dim == 2 else policy_plot[..., 0].T


### PR DESCRIPTION
- Upgraded method `set_window_title` to avoid deprecation (matplotlib 3.4): `fig.canvas.set_window_title` was deprecated with the arrival of version 3.4, and required an update to `fig.canvas.manager.set_window_title`;
- Added function call to manually add `Axes3D` to a figure. It is currently added automatically, but that behavior will change to be consistent with other types of axes in a future version. Commit b056dd4 fixes that preemptively, before argument `auto_add_to_figure` defaults to `False`. More details [here](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.4.0.html#axes3d-automatically-adding-itself-to-figure-is-deprecated).