### PR TITLE
Use solve_ivp instead of deprecated odeint

### DIFF
--- a/pyro/dynamic/system.py
+++ b/pyro/dynamic/system.py
@@ -403,8 +403,8 @@ class ContinuousDynamicSystem:
         
     #############################
     def compute_trajectory(
-        self, tf=10, n=10001, solver='ode'):
-        """ 
+        self, tf=10, n=None, solver='ode', **solver_args):
+        """
         Simulation of time evolution of the system
         ------------------------------------------------
         tf : final time
@@ -413,7 +413,8 @@ class ContinuousDynamicSystem:
 
         sim = simulation.Simulator(self, tf, n, solver)
 
-        self.traj = sim.compute() # save the result in the instance
+        # solve and save the result in the instance
+        self.traj = sim.compute(**solver_args)
 
         return self.traj
 


### PR DESCRIPTION
scipy.integrate.odeint is deprecated and recommended to be replaced by solve_ivp, which also has more options (can choose stiff solvers, etc.)

In addition to using solve_ivp, this commit introduces the following changes:

* Default number of points (n) for `compute_trajectory` is now `None`, which is a solver-specific default. For 'euler', the default is still 10001 points. For `ode` (solve_ivp), the default points are those chosen by the ODE solver. If the number of points is specified, a `linspace` vector is generated and passed as the `t_eval` argument of solve_ivp.

* Extra keyword arguments to `compute_trajectory` are passed through to `solve_ivp`. This allows controlling behavior of solve_ivp such as which solver is used (RK45, RK23, Radau, etc) or the solver precision tolerance (rtol, atol).