### PR TITLE
Add covariance matrix P to Kalman observers

### DIFF
--- a/examples/projects/tests/StateObserver/.gitignore
+++ b/examples/projects/tests/StateObserver/.gitignore
@@ -1,0 +1,3 @@
+# csv data created by matlab script
+*.csv
+*.mat

--- a/examples/projects/tests/StateObserver/observer_twodofss.m
+++ b/examples/projects/tests/StateObserver/observer_twodofss.m
@@ -22,6 +22,7 @@ N = zeros(2, 1);
 
 [kalmf,L,P] = kalman(sys, Q, R, N);
 L
+P
 
 %% Simulation
 
@@ -56,5 +57,7 @@ x_est_q = interp1(t, x_est, tq);
 plot(tq, x_est_q, 'o');
 
 writematrix(x_est_q, 'x_est.csv')
+
+save("matlab_data.mat", "x_est", "tOut", "stateOut", "-v7")
 
 

--- a/examples/projects/tests/StateObserver/test_stateobserver.py
+++ b/examples/projects/tests/StateObserver/test_stateobserver.py
@@ -42,7 +42,6 @@ class Test_Obs_TwoDofSs():
 
         L = np.empty([2, 1])
         obs = StateObserver.from_ss(sys, L)
-        return True
 
     def test_kalman_gain_from_ss(self):
         sys = TwoDofSs()
@@ -50,8 +49,16 @@ class Test_Obs_TwoDofSs():
         R = 0.9575;
         kf = StateObserver.kalman_from_ss(sys, Q, R)
 
+        # Kalman gain
         L_matlab = np.array([0.241879988531013, 0.163053708572278]).reshape(2, 1) * 1E-3
+
+        # Oberserver covariance matrix
+        P_matlab = np.array([
+            [0.530701428966605, 0.231600089018445],
+            [0.231600089018445, 0.156123925957956]
+        ]) * 1E-3
         np.testing.assert_array_almost_equal(kf.L, L_matlab)
+        np.testing.assert_array_almost_equal(kf.P, P_matlab)
 
     def test_kalman_gain_from_ABCD(self):
         sys = TwoDofSs()
@@ -59,8 +66,17 @@ class Test_Obs_TwoDofSs():
         R = 0.9575;
         kf = StateObserver.kalman(sys.A, sys.B, sys.C, sys.D, Q, R)
 
+        # Kalman gain
         L_matlab = np.array([0.241879988531013, 0.163053708572278]).reshape(2, 1) * 1E-3
+
+        # Oberserver covariance matrix
+        P_matlab = np.array([
+            [0.530701428966605, 0.231600089018445],
+            [0.231600089018445, 0.156123925957956]
+        ]) * 1E-3
+
         np.testing.assert_array_almost_equal(kf.L, L_matlab)
+        np.testing.assert_array_almost_equal(kf.P, P_matlab)
 
     def test_kalman_check_dims(self):
         sys = TwoDofSs()
@@ -108,7 +124,8 @@ class Test_Obs_TwoDofSs():
         kf.x0 = np.array([0, 0])
 
         osys = kf + sys
-        traj = osys.compute_trajectory(tf=10_000, n=50)
+        tf = 10_000
+        traj = osys.compute_trajectory(tf=tf, n=50, method="DOP853", rtol=1E-4, atol=1E-3)
 
         # Matlab generated data
         expected_x_est_txt = """
@@ -177,3 +194,7 @@ class Test_Obs_TwoDofSs():
 
         # Compare against matlab with 0.1 % error
         np.testing.assert_allclose(expected_x_est, traj.y, rtol=1E-3, atol=0.01)
+
+if __name__ == "__main__":
+    import scipy.io
+    Test_Obs_TwoDofSs().test_sim_observed_sys()

--- a/pyro/dynamic/statespace.py
+++ b/pyro/dynamic/statespace.py
@@ -408,7 +408,9 @@ class StateObserver(StateSpaceSystem):
         Returns
         ----------
 
-        Instance of `StateObserver` with L, the Kalman gain matrix.
+        Instance of `StateObserver` with L, the Kalman gain matrix. A special
+        property `P` is set which corresponds to the state estimation
+        covariance matrix.
 
         """
         Q = np.array(Q, ndmin=2, dtype=np.float64)
@@ -442,6 +444,7 @@ class StateObserver(StateSpaceSystem):
         assert L_kalm.shape == obs.L.shape
 
         obs.L = L_kalm
+        obs.P = P # estimate covariance matrix
         return obs
 
 
@@ -455,12 +458,16 @@ class StateObserver(StateSpaceSystem):
         Returns
         ----------
 
-        Instance of `StateObserver` with L, the Kalman gain matrix.
+        Instance of `StateObserver` with L, the Kalman gain matrix. A special
+        property `P` is set which corresponds to the state estimation
+        covariance matrix.
 
         """
 
-        L = cls.kalman(ss.A, ss.B, ss.C, ss.D, Q, R, G).L
-        return cls.from_ss(ss, L)
+        kalm_obs = cls.kalman(ss.A, ss.B, ss.C, ss.D, Q, R, G)
+        result = cls.from_ss(ss, kalm_obs.L)
+        result.P = kalm_obs.P
+        return result
 
 
     def h(self, x, u, t):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     install_requires=[
         'numpy>=1.10',
         'matplotlib>3.0',
-        'scipy>=1.2'
+        'scipy>=1.5.2'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Add property `P`, corresponding to the state estimation covariance matrix, to instances of `StateObserver` created using one of the Kalman class methods.
- Add test that compares the covariance matrix to the one calculated by Matlab
- Fix test `test_sim_observed_sys`, I think it was broken when the ODE solver was switched to `solve_ivp` (need to increase the default precision).